### PR TITLE
Don't upload mesh geometry every frame.

### DIFF
--- a/main.js
+++ b/main.js
@@ -406,9 +406,9 @@ const drawGbuffer = regl({
 })
 
 function Mesh (elements, position, normal) {
-  this.elements = elements
-  this.position = position
-  this.normal = normal
+  this.elements = regl.elements(elements);
+  this.position = regl.buffer(position);
+  this.normal = regl.buffer(normal);
 }
 
 // get single matrix from quaternion, translation and scale.


### PR DESCRIPTION
This is the bottleneck on my PC (AMD R9 290x). Fixing this increases the performance of the demo from  ~30fps to the framerate cap (60fps).